### PR TITLE
Drop lodash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 *.js
 !karma.conf.js
 *.map
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ npm-debug.log
 *.js
 !karma.conf.js
 *.map
-.idea

--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ abstract class NgComponent<Props, State> {
       try {
         newProps[key] = newProps[key]['currentValue']
       } catch (e) {}
-      didPropsChange = didPropsChange || (newProps[key] === oldProps[key])
+      didPropsChange = didPropsChange || (newProps[key] !== oldProps[key])
     }
     const nextProps = {
         ...(this.props as any as object),

--- a/index.ts
+++ b/index.ts
@@ -13,8 +13,8 @@ abstract class NgComponent<Props, State> {
   */
   // nb: this method is explicity exposed for unit testing
   public $onChanges(changes: object) {
-    const oldProps = clone(changes)
-    const newProps = clone(changes)
+    const oldProps: object = clone(changes)
+    const newProps: object = clone(changes)
     const changeKeys = Object.getOwnPropertyNames(changes)
     let didPropsChange = false
     for (let i = 0; i < changeKeys.length; ++i) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
   },
   "dependencies": {
     "@types/angular": "^1.6.16",
-    "angular": ">=1.5.0",
+    "angular": ">=1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "author": "Boris Cherny <boris@performancejs.com>",
   "contributors": [
-    "Chris Khoo <chris.khoo@gmail.com>",
+    "Chris Khoo <chris.khoo@gmail.com>"
   ],
   "license": "Apache-2.0",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "author": "Boris Cherny <boris@performancejs.com>",
   "contributors": [
-    "Chris Khoo <chris.khoo@gmail.com>"
+    "Chris Khoo <chris.khoo@gmail.com>",
   ],
   "license": "Apache-2.0",
   "bugs": {
@@ -38,6 +38,7 @@
   "homepage": "https://github.com/coatue-oss/ngcomponent#readme",
   "devDependencies": {
     "@types/jasmine": "^2.5.47",
+    "@types/lodash.assign": "^4.2.2",
     "browserify": "^14.3.0",
     "electron": "^1.6.6",
     "jasmine": "^2.6.0",
@@ -47,6 +48,7 @@
     "karma-jasmine": "^1.1.0",
     "karma-mocha-reporter": "^2.2.3",
     "karma-source-map-support": "^1.2.0",
+    "lodash.assign": "^4.2.0",
     "ngimport": "^0.7.0",
     "rollupify": "^0.3.9",
     "tslint": "^5.1.0",
@@ -59,12 +61,6 @@
   },
   "dependencies": {
     "@types/angular": "^1.6.16",
-    "@types/lodash.assign": "^4.2.2",
-    "@types/lodash.mapvalues": "^4.6.2",
-    "@types/lodash.some": "^4.6.2",
     "angular": ">=1.5.0",
-    "lodash.assign": "^4.2.0",
-    "lodash.mapvalues": "^4.6.0",
-    "lodash.some": "^4.6.0"
   }
 }


### PR DESCRIPTION
Dropping lodash shaved 70kb off our webpack production build.

I left it in tests because that doesn't affect the build weight.

Replaced lodash tools with common ES6/7 features. I believe typescript should handle these correctly for valid non-evergreen targets but I haven't done TS in a couple of years.

Also, kept my editor from infecting your repo.

Thanks for an awesome and lightweight tool that is really accelerating our development! 🎉 