### PR TITLE
Require per-method Lodash packages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
-import {assign, mapValues, some} from 'lodash'
+const some = require('lodash.some')
+const assign = require('lodash.assign')
+const mapValues = require('lodash.mapvalues')
 
 abstract class NgComponent<Props, State> {
 
@@ -15,8 +17,8 @@ abstract class NgComponent<Props, State> {
   */
   // nb: this method is explicity exposed for unit testing
   public $onChanges(changes: object) {
-    const oldProps = mapValues<{}, Props>(changes, 'previousValue')
-    const newProps = mapValues<{}, Props>(changes, 'currentValue')
+    const oldProps = mapValues(changes, 'previousValue')
+    const newProps = mapValues(changes, 'currentValue')
 
     const nextProps = assign({}, this.props, newProps)
     // TODO: implement nextState (which also means implement this.setState)

--- a/test.ts
+++ b/test.ts
@@ -1,7 +1,8 @@
 import { bootstrap, element, IControllerConstructor, Injectable, IScope, module } from 'angular'
-import { assign } from 'lodash'
 import { $compile, $rootScope } from 'ngimport'
 import NgComponent from './'
+
+const assign = require('lodash.assign')
 
 interface Props {
   a: number


### PR DESCRIPTION
I tried a few permutations and eventually the TypeScript-specific
`import some = require('lodash.some')`, which works fine for the ES5
build, but not ES2015 per:

https://github.com/Microsoft/TypeScript/issues/15426.

Falling back to a standard `require` was the only way I could make this
work (thus far).

However, this means `index.es2015.js` is no longer an ES module. Lmk if
there's a better way of this.

Closes #36.