### PR TITLE
move @types to devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
   },
   "homepage": "https://github.com/coatue-oss/ngcomponent#readme",
   "devDependencies": {
+    "@types/angular": "^1.6.42",
     "@types/angular-mocks": "^1.5.11",
     "@types/jasmine": "^2.8.6",
+    "@types/lodash": "^4.14.102",
     "angular-resource": "^1.6.9",
     "browserify": "^16.0.0",
     "electron": "^1.8.2",
@@ -60,8 +62,6 @@
     "xvfb-maybe": "^0.2.1"
   },
   "dependencies": {
-    "@types/angular": "^1.6.42",
-    "@types/lodash": "^4.14.102",
     "angular": "^1.6.9",
     "lodash": "^4.17.5"
   }


### PR DESCRIPTION
Jquery has changed their types, and now when installing `@types/jquery@2`  and `ngcomponent`, and compile with typescript, you'll get `error TS2717: Subsequent property declarations must have the same type. Property 'char' must be of type 'string'`.
The source for this conflict is `@types/jquery` and `@types/angular`.

Moving `@types/angular` to devDependencies would solve it.
I think it's a better practice to move all `@types` to devDependencies, so I moved `@types/lodash` as well.